### PR TITLE
SCP-4420 Fix kraken value set

### DIFF
--- a/marlowe-playground-client/src/Component/CurrencyInput/State.purs
+++ b/marlowe-playground-client/src/Component/CurrencyInput/State.purs
@@ -16,7 +16,8 @@ component
 component = H.mkComponent
   { initialState: deriveState
   , render
-  , eval: H.mkEval $ H.defaultEval { handleAction = handleAction }
+  , eval: H.mkEval $ H.defaultEval
+      { handleAction = handleAction, receive = Just <<< Receive }
   }
 
 deriveState :: Input -> State

--- a/marlowe-playground-client/src/Component/DecimalInput.purs
+++ b/marlowe-playground-client/src/Component/DecimalInput.purs
@@ -6,7 +6,7 @@ import Data.Decimal (Decimal)
 import Data.Decimal as D
 import Data.Either (Either(..))
 import Data.Int as I
-import Data.Lens (over) as L
+import Data.Lens (set) as L
 import Data.Lens.Record (prop) as L
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Number (pow)
@@ -40,7 +40,8 @@ type Input =
   }
 
 data Action
-  = ChangeValue String
+  = OnBlur
+  | OnInput String
   | Receive Input
 
 type Output = Either String Decimal
@@ -51,18 +52,23 @@ type State =
   , value :: String
   }
 
+valueAsString :: Decimal -> Natural -> String
+valueAsString value _ | value == zero = ""
+valueAsString value precision = printDecimal precision value
+
 component
   :: forall query m
    . MonadEffect m
   => H.Component query Input Output m
 component = H.mkComponent
-  { initialState: case _ of
-      i@{ value } | value == zero -> i { value = "" }
-      i -> L.over (L.prop (Proxy :: Proxy "value")) (printDecimal i.precision) i
+  { initialState: \i -> L.set (L.prop (Proxy :: Proxy "value"))
+      (valueAsString i.value i.precision)
+      i
   , render
   , eval: H.mkEval $
       H.defaultEval
         { handleAction = handleAction
+        , receive = Just <<< Receive
         }
   }
 
@@ -71,15 +77,20 @@ handleAction
    . MonadEffect m
   => Action
   -> H.HalogenM State Action slots Output m Unit
-handleAction (ChangeValue s) = do
-  case D.fromString s of
-    Just v -> H.raise $ Right v
-    Nothing -> H.raise $ Left s
-  H.modify_ _ { value = s }
+handleAction (OnInput s) = H.modify_ _ { value = s }
 
-handleAction (Receive _) =
-  info
-    "Input updates are not allowed in input to prevent cursor position changes"
+handleAction OnBlur = do
+  state <- H.get
+  case D.fromString state.value of
+    Just v -> do
+      H.raise $ Right v
+    Nothing -> do
+      H.raise $ Left state.value
+
+handleAction (Receive input) = do
+  state <- H.get
+  when (state.value /= valueAsString input.value input.precision)
+    $ H.modify_ _ { value = valueAsString input.value input.precision }
 
 printDecimal :: Natural -> Decimal -> String
 printDecimal precision = D.toFixed (N.toInt precision)
@@ -90,10 +101,8 @@ refLabel = RefLabel "Component.DecimalInput.input"
 render :: forall w. State -> HH.HTML w Action
 render state = HH.input
   [ HH.classNames $ state.classList
-  , HH.onValueInput ChangeValue
-  , HH.onBlur $ const $ ChangeValue $ fromMaybe state.value do
-      d <- D.fromString state.value
-      pure $ printDecimal state.precision d
+  , HH.onValueInput OnInput
+  , HH.onBlur $ const $ OnBlur
   , HH.step $ HH.Step (pow 10.0 (I.toNumber $ -1 * N.toInt state.precision))
   , HH.placeholder $ printDecimal state.precision $ D.fromInt 0
   , HH.type_ HH.InputNumber

--- a/marlowe-playground-client/src/Component/DecimalInput.purs
+++ b/marlowe-playground-client/src/Component/DecimalInput.purs
@@ -8,12 +8,11 @@ import Data.Either (Either(..))
 import Data.Int as I
 import Data.Lens (set) as L
 import Data.Lens.Record (prop) as L
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe(..))
 import Data.Number (pow)
 import Data.Numbers.Natural (Natural)
 import Data.Numbers.Natural as N
 import Effect.Class (class MonadEffect)
-import Effect.Class.Console (info)
 import Halogen (RefLabel(..))
 import Halogen as H
 import Halogen.Css (classNames) as HH


### PR DESCRIPTION
This PR fixes a bug with the karken values not being updated. The problem had to do with the component not receiving updates from parent components. The reason this was disallowed was that the cursor moved to the end whenever you modified. I solved this by splitting the internal component state  (on input value change)  from informing parents of changes (on input blur).

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
