### PR TITLE
PLT-3913 - Fix bug converting Address from Marlowe to Blockly

### DIFF
--- a/marlowe-playground-client/src/Blockly/Internal.js
+++ b/marlowe-playground-client/src/Blockly/Internal.js
@@ -56,7 +56,7 @@ export const createWorkspace =
         }
       };
 
-      ["currency_symbol", "pubkey"].forEach(function (fieldName) {
+      ["currency_symbol"].forEach(function (fieldName) {
         var field = thisBlock.getField(fieldName);
         if (field != null) {
           field.setValidator(hashValidator);

--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -1763,7 +1763,7 @@ instance toBlocklyParty :: ToBlockly Party where
   toBlockly newBlock workspace input (Address address) = do
     block <- newBlock workspace (show AddressPartyType)
     connectToOutput block input
-    setField block "pubkey" address
+    setField block "address" address
   toBlockly newBlock workspace input (Role role) = do
     block <- newBlock workspace (show RolePartyType)
     connectToOutput block input


### PR DESCRIPTION
This PR fixes a bug with the Blockly editor where converting an Address to a block was lost.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
