### PR TITLE
PLT-5466 - Fix JS version of the CFD with oracle

### DIFF
--- a/marlowe-playground-client/spago-packages.nix
+++ b/marlowe-playground-client/spago-packages.nix
@@ -787,11 +787,11 @@ let
 
     "marlowe" = pkgs.stdenv.mkDerivation {
       name = "marlowe";
-      version = "b1b556905c672ec0ae811fa4e48b367b5e7c5d5d";
+      version = "f97fb0fa7f23bc4631e6acafadd52c3303ea77e9";
       src = pkgs.fetchgit {
         url = "https://github.com/input-output-hk/purescript-marlowe";
-        rev = "b1b556905c672ec0ae811fa4e48b367b5e7c5d5d";
-        sha256 = "0rg8gmns0vavd6izkn3vjmwxdsjv4jvl3vpbyilb1a9mb2888fch";
+        rev = "f97fb0fa7f23bc4631e6acafadd52c3303ea77e9";
+        sha256 = "19zdnsb8h986dgbzliy0z4cvdmm6g2w46cwgqr37kalnvhfx3k8i";
       };
       phases = "installPhase";
       installPhase = "ln -s $src $out";
@@ -1628,11 +1628,12 @@ in
   '';
 
   buildFromNixStore = pkgs.writeShellScriptBin "build-from-store" ''
-    set -e
-    echo building project using sources from nix store...
-    purs compile ${builtins.toString (
-      builtins.map getStoreGlob (builtins.attrValues inputs))} "$@"
-    echo done.
+          set -e
+          echo building project using sources from nix store...
+          purs compile ${builtins.toString (
+            builtins.map getStoreGlob (builtins.attrValues inputs)
+    )} "$@"
+          echo done.
   '';
 
   mkBuildProjectOutput =

--- a/marlowe-playground-client/src/Examples/JS/Contracts.purs
+++ b/marlowe-playground-client/src/Examples/JS/Contracts.purs
@@ -504,7 +504,7 @@ contractForDifferencesWithOracle =
 
     function recordEndPrice(name: ValueId, choiceId1: ChoiceId, choiceId2: ChoiceId,
         continuation: Contract): Contract {
-        return Let(name, DivValue(MulValue(priceBeginning, MulValue(ChoiceValue(choiceId1), ChoiceValue(choiceId2))), (Constant 10_000_000_000_000_000n)),
+        return Let(name, DivValue(MulValue(priceBeginning, MulValue(ChoiceValue(choiceId1), ChoiceValue(choiceId2))), (Constant (10_000_000_000_000_000n))),
             continuation);
     }
 

--- a/packages.dhall
+++ b/packages.dhall
@@ -209,4 +209,6 @@ in  upstream
         , "unfoldable"
         ]
         "https://github.com/input-output-hk/purescript-marlowe"
-        "b1b556905c672ec0ae811fa4e48b367b5e7c5d5d"
+        -- THIS COMMIT IS A BRANCH-OFF MAIN WITHOUT MERKLEIZATION AND WITH SOME DECODING
+        -- FIX. WE NEED TO UPGRADE THE PLAYGROUND TO HANDLE MERKLEIZATION
+        "f97fb0fa7f23bc4631e6acafadd52c3303ea77e9"


### PR DESCRIPTION
This PR fixes the JS example of the contract for difference with oracle.

There were 2 issues, a parenthesis missing in the JS file, and I had to patch a non-merkleized version of purescript-marlowe with [this fix](https://github.com/input-output-hk/purescript-marlowe/pull/18)
