### PR TITLE
PLT-5930: Add dependencies needed for e2e tests.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1032,6 +1032,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-babel": {
+      "locked": {
+        "lastModified": 1685792587,
+        "narHash": "sha256-SJZySQ1eblQWeNxCU0R7Ly1ZTQOW9A942eNNo/hQq2I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "39addc620d1585c4d95246f4e47c83467ae3e62a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "39addc620d1585c4d95246f4e47c83467ae3e62a",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -1342,6 +1358,7 @@
           "haskell-nix",
           "nixpkgs-unstable"
         ],
+        "nixpkgs-babel": "nixpkgs-babel",
         "npmlock2nix": "npmlock2nix",
         "pre-commit-hooks": "pre-commit-hooks",
         "std": "std_2"

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,7 @@
       url = "github:NixOS/nixpkgs";
       follows = "haskell-nix/nixpkgs-unstable";
     };
+    nixpkgs-babel.url = "github:NixOS/nixpkgs?rev=39addc620d1585c4d95246f4e47c83467ae3e62a";
     haskell-nix = {
       url = "github:input-output-hk/haskell.nix";
       inputs.hackage.follows = "hackage";


### PR DESCRIPTION
Note that tests now fail with:

> 
> Error: ENOENT: no such file or directory, scandir '/home/shlevy/src/iog/marlowe-playground/e2e/config/mappings/fixtures/'
> 

and later

> /home/shlevy/src/iog/marlowe-playground/e2e/node_modules/cucumber-html-reporter/lib/hierarchyReporter.js:20
>     suite.features.forEach(function (feature) {
>                    ^
> TypeError: suite.features.forEach is not a function
