### PR TITLE
PLT-7427 - Add button to export contract to Marlowe Runner

### DIFF
--- a/changelog.d/20230922_035409_pablo.lamela_PLT_7427.md
+++ b/changelog.d/20230922_035409_pablo.lamela_PLT_7427.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- Added button to export contracts to Marlowe Runner 
+
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/marlowe-playground-client/spago.dhall
+++ b/marlowe-playground-client/spago.dhall
@@ -41,6 +41,7 @@
   , "integers"
   , "js-object"
   , "js-timers"
+  , "js-uri"
   , "json-helpers"
   , "lists"
   , "markdown"

--- a/marlowe-playground-client/src/Component/Modal/View.purs
+++ b/marlowe-playground-client/src/Component/Modal/View.purs
@@ -10,6 +10,7 @@ import Component.NewProject.View (render) as NewProject
 import Component.Projects.View (render) as Projects
 import Data.Lens ((^.))
 import Effect.Aff.Class (class MonadAff)
+import ExportToRunner (exportToRunnerForm)
 import GistButtons (authButton)
 import Halogen (ComponentHTML)
 import Halogen.Extra (renderSubmodule)
@@ -61,3 +62,5 @@ modal state = case state ^. _showModal of
       intendedAction
       state
     (GithubLogin intendedAction) -> authButton intendedAction state
+    (ExportToRunnerModal contractString) -> exportToRunnerForm contractString
+      state

--- a/marlowe-playground-client/src/ExportToRunner.purs
+++ b/marlowe-playground-client/src/ExportToRunner.purs
@@ -23,9 +23,9 @@ exportToRunnerForm contractString _state =
         , div_
             do
               (title /\ url) <-
-                [ ("Mainnet" /\ "")
-                , ("Preprod" /\ "")
-                , ("Preview" /\ "")
+                [ ("Mainnet" /\ "https://mainnet.runner.marlowe.iohk.io/")
+                , ("Preprod" /\ "https://preprod.runner.marlowe.iohk.io/")
+                , ("Preview" /\ "https://preview.runner.marlowe.iohk.io/")
                 ]
               pure $ a
                 [ idPublishGist

--- a/marlowe-playground-client/src/ExportToRunner.purs
+++ b/marlowe-playground-client/src/ExportToRunner.purs
@@ -1,0 +1,38 @@
+module ExportToRunner (exportToRunnerForm) where
+
+import Prologue hiding (div)
+
+import Component.Modal.ViewHelpers (modalHeader)
+import Data.Tuple.Nested ((/\))
+import Gists.View (idPublishGist)
+import Halogen.Classes (modalContent)
+import Halogen.HTML (ClassName(..), HTML, a, div, div_, p, text)
+import Halogen.HTML.Events (onClick)
+import Halogen.HTML.Properties (classes)
+import MainFrame.Types (Action(..), State)
+
+exportToRunnerForm :: forall p. String -> State -> HTML p Action
+exportToRunnerForm contractString _state =
+  div_
+    [ modalHeader "Export to Marlowe Runner" (Just CloseModal)
+    , div [ classes [ modalContent ] ]
+        [ p [ classes [ ClassName "mb-3" ] ]
+            [ text
+                "On what network would you like to deploy the contract?"
+            ]
+        , div_
+            do
+              (title /\ url) <-
+                [ ("Mainnet" /\ "")
+                , ("Preprod" /\ "")
+                , ("Preview" /\ "")
+                ]
+              pure $ a
+                [ idPublishGist
+                , classes [ ClassName "auth-button", ClassName "mx-3" ]
+                , onClick $ const $ SendToRunner url contractString
+                ]
+                [ text title
+                ]
+        ]
+    ]

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -16,6 +16,7 @@ import Control.Monad.Except (ExceptT(..), lift, runExceptT)
 import Control.Monad.Maybe.Extra (hoistMaybe)
 import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
 import Control.Monad.State (modify_)
+import Data.Argonaut (encodeJson, stringify)
 import Data.Argonaut.Extra (encodeStringifyJson, parseDecodeJson)
 import Data.Bifunctor (lmap)
 import Data.Either (either, hush, note)
@@ -37,11 +38,12 @@ import Gists.Types (parseGistUrl) as Gists
 import Halogen (Component, liftEffect, subscribe')
 import Halogen as H
 import Halogen.Analytics (withAnalytics)
-import Halogen.Extra (mapSubmodule)
+import Halogen.Extra (imapState, mapSubmodule)
 import Halogen.Monaco (KeyBindings(DefaultBindings))
 import Halogen.Monaco as Monaco
 import Halogen.Query (HalogenM)
 import Halogen.Query.Event (eventListener)
+import Language.Marlowe.Core.V1.Semantics.Types (Contract)
 import Language.Marlowe.Extended.V1.Metadata
   ( emptyContractMetadata
   , getHintsFromMetadata
@@ -83,6 +85,7 @@ import MainFrame.View (render)
 import Marlowe (Api, getApiGistsByGistId)
 import Marlowe as Server
 import Marlowe.Gists (PlaygroundFiles, mkNewGist, mkPatchGist, playgroundFiles)
+import Marlowe.Holes (fromTerm)
 import Network.RemoteData (RemoteData(..), _Success, fromEither)
 import Page.BlocklyEditor.State as BlocklyEditor
 import Page.BlocklyEditor.Types (_marloweCode)
@@ -454,6 +457,18 @@ handleAction (SimulationAction action) = do
     ST.EditSource -> do
       mLang <- use _workflow
       for_ mLang \lang -> selectView $ selectLanguageView lang
+    ST.ExportToRunner -> do
+      result <- imapState _simulationState
+        ( runMaybeT $ do
+            extendedContract <- MaybeT Simulation.mkContract
+            coreContract :: Contract <- MaybeT $ pure $ fromTerm
+              extendedContract
+            pure $ stringify $ encodeJson coreContract
+        )
+      case result of
+        Just contract -> modify_
+          (set _showModal (Just $ ExportToRunnerModal contract))
+        Nothing -> pure unit
     _ -> pure unit
 
 handleAction (ChangeView view) = selectView view
@@ -622,6 +637,9 @@ handleAction (OpenModal RenameProject) = do
 handleAction (OpenModal modalView) = assign _showModal $ Just modalView
 
 handleAction CloseModal = assign _showModal Nothing
+
+handleAction (SendToRunner _url _contractString) = do
+  handleAction CloseModal
 
 handleAction (OpenLoginPopup intendedAction) = do
   authRole <- liftAff openLoginPopup

--- a/marlowe-playground-client/src/MainFrame/Types.purs
+++ b/marlowe-playground-client/src/MainFrame/Types.purs
@@ -57,6 +57,7 @@ data ModalView
   | SaveProjectAs
   | GithubLogin Action
   | ConfirmUnsavedNavigation Action
+  | ExportToRunnerModal String
 
 derive instance genericModalView :: Generic ModalView _
 
@@ -68,6 +69,7 @@ instance showModalView :: Show ModalView where
   show SaveProjectAs = "SaveProjectAs"
   show (ConfirmUnsavedNavigation _) = "ConfirmUnsavedNavigation"
   show (GithubLogin _) = "GithubLogin"
+  show (ExportToRunnerModal _) = "ExportToRunnerModal"
 
 -- Before adding the intended action to GithubLogin, this instance was being
 -- handled by the genericShow. Action does not have a show instance so genericShow
@@ -99,6 +101,7 @@ data Action
   | GistAction GistAction
   | OpenModal ModalView
   | CloseModal
+  | SendToRunner String String
   | OpenLoginPopup Action
 
 -- | Here we decide which top-level queries to track as GA events, and
@@ -127,6 +130,7 @@ instance actionIsEvent :: IsEvent Action where
     { category = Just "OpenModal" }
   toEvent CloseModal = Just $ defaultEvent "CloseModal"
   toEvent (OpenLoginPopup _) = Just $ defaultEvent "OpenLoginPopup"
+  toEvent (SendToRunner _ _) = Just $ defaultEvent "SendToRunner"
   toEvent Logout = Just $ defaultEvent "Logout"
 
 data View

--- a/marlowe-playground-client/src/Page/Simulation/State.purs
+++ b/marlowe-playground-client/src/Page/Simulation/State.purs
@@ -3,6 +3,7 @@ module Page.Simulation.State
   , editorGetValue
   , getCurrentContract
   , mkStateBase
+  , mkContract
   ) where
 
 import Prologue hiding (div)
@@ -126,11 +127,11 @@ toBottomPanel
 toBottomPanel = mapSubmodule _bottomPanelState BottomPanelAction
 
 mkContract
-  :: forall m
+  :: forall m a
    . MonadAff m
   => MonadEffect m
   => MonadAjax Api m
-  => HalogenM State Action ChildSlots Void m (Maybe (Term Term.Contract))
+  => HalogenM State a ChildSlots Void m (Maybe (Term Term.Contract))
 mkContract = runMaybeT do
   termContract <- MaybeT $ peruse
     ( _currentMarloweState

--- a/marlowe-playground-client/src/Page/Simulation/State.purs
+++ b/marlowe-playground-client/src/Page/Simulation/State.purs
@@ -273,6 +273,8 @@ handleAction _ (ShowRightPanel val) = assign _showRightPanel val
 
 handleAction _ EditSource = pure unit
 
+handleAction _ ExportToRunner = pure unit
+
 stripPair :: String -> Boolean /\ String
 stripPair pair = case splitAt 4 pair of
   { before, after }

--- a/marlowe-playground-client/src/Page/Simulation/Types.purs
+++ b/marlowe-playground-client/src/Page/Simulation/Types.purs
@@ -60,6 +60,7 @@ data Action
   | ShowRightPanel Boolean
   | BottomPanelAction (BottomPanel.Action BottomPanelView Action)
   | EditSource
+  | ExportToRunner
 
 defaultEvent :: String -> Event
 defaultEvent s = A.defaultEvent $ "Simulation." <> s
@@ -82,6 +83,7 @@ instance isEventAction :: IsEvent Action where
   toEvent (BottomPanelAction action) = A.toEvent action
   toEvent EditSource = Just $ defaultEvent "EditSource"
   toEvent (HandleEditorMessage _) = Just $ defaultEvent "HandleEditorMessage"
+  toEvent ExportToRunner = Just $ defaultEvent "ExportToRunner"
 
 data Query a = WebsocketResponse (RemoteData String Result) a
 

--- a/marlowe-playground-client/src/Page/Simulation/View.purs
+++ b/marlowe-playground-client/src/Page/Simulation/View.purs
@@ -397,6 +397,12 @@ startSimulationWidget
             , button
                 [ classNames
                     [ "btn", "bold", "flex-1", "max-w-[15rem]", "mx-2" ]
+                , onClick $ const ExportToRunner
+                ]
+                [ text "Export to Marlowe Runner" ]
+            , button
+                [ classNames
+                    [ "btn", "bold", "flex-1", "max-w-[15rem]", "mx-2" ]
                 , onClick $ const StartSimulation
                 ]
                 [ text "Start simulation" ]

--- a/marlowe-playground-client/src/Page/Simulation/View.purs
+++ b/marlowe-playground-client/src/Page/Simulation/View.purs
@@ -89,7 +89,6 @@ import Halogen.HTML
   , section
   , slot
   , span
-  , span_
   , strong_
   , text
   , ul


### PR DESCRIPTION
This PR adds a new button "Export to Marlowe Runner" to the simulator sidebar between "Download JSON" and "Start simulation" that opens a pop-up that allows user to select a Cardano network (out of "Mainnet", "Preprod", and "Preview"). When clicked, they will open a new tab with Marlowe Runner and the current contract (with the values from the form filled-in) loaded, prepared to deploy.

![export-to-runner](https://github.com/input-output-hk/marlowe-playground/assets/638102/5c56caec-fbad-40cd-8252-c7e4725170e1)


Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
