### PR TITLE
PLT-8206 - Add GET endpoint to import contracts

### DIFF
--- a/changelog.d/20231024_024818_pablo.lamela_PLT_8206.md
+++ b/changelog.d/20231024_024818_pablo.lamela_PLT_8206.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- Added endpoint to import contracts from other websites 
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -108,7 +108,7 @@ import Page.JavascriptEditor.Types
   ) as JS
 import Page.JavascriptEditor.Types (CompilationState(..))
 import Page.MarloweEditor.State as MarloweEditor
-import Page.MarloweEditor.Types as ME
+import Page.MarloweEditor.Types (Action(..), State, initialState) as ME
 import Page.Simulation.State as Simulation
 import Page.Simulation.Types as ST
 import Rename.State (handleAction) as Rename
@@ -256,6 +256,11 @@ handleSubRoute Router.Home = selectView HomePage
 handleSubRoute Router.Simulation = selectView Simulation
 
 handleSubRoute Router.MarloweEditor = selectView MarloweEditor
+
+handleSubRoute (Router.ImportContract contract) = do
+  handleActionWithoutNavigationGuard
+    (MarloweEditorAction (ME.ImportCompressedJSON contract))
+  selectView MarloweEditor
 
 handleSubRoute Router.HaskellEditor = selectView HaskellEditor
 
@@ -697,6 +702,7 @@ routeToView { subroute } = case subroute of
   Router.Simulation -> Just Simulation
   Router.HaskellEditor -> Just HaskellEditor
   Router.MarloweEditor -> Just MarloweEditor
+  Router.ImportContract _ -> Just MarloweEditor
   Router.JSEditor -> Just JSEditor
   Router.Blockly -> Just BlocklyEditor
   Router.GithubAuthCallback -> Nothing

--- a/marlowe-playground-client/src/Page/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/Page/MarloweEditor/Types.purs
@@ -32,6 +32,7 @@ data Action
   | MoveToPosition Pos Pos
   | LoadScript String
   | SetEditorText String
+  | ImportCompressedJSON String
   | BottomPanelAction (BottomPanel.Action BottomPanelView Action)
   | ShowErrorDetail Boolean
   | SendToSimulator
@@ -59,6 +60,7 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (LoadScript script) = Just $ (defaultEvent "LoadScript")
     { label = Just script }
   toEvent (SetEditorText _) = Just $ defaultEvent "SetEditorText"
+  toEvent (ImportCompressedJSON _) = Just $ defaultEvent "ImportCompressedJSON"
   toEvent (BottomPanelAction action) = A.toEvent action
   toEvent (ShowErrorDetail _) = Just $ defaultEvent "ShowErrorDetail"
   toEvent SendToSimulator = Just $ defaultEvent "SendToSimulator"

--- a/marlowe-playground-client/src/Router.purs
+++ b/marlowe-playground-client/src/Router.purs
@@ -20,6 +20,7 @@ data SubRoute
   = Home
   | Simulation
   | MarloweEditor
+  | ImportContract String
   | HaskellEditor
   | JSEditor
   | Blockly
@@ -39,12 +40,15 @@ route =
           { "Home": noArgs
           , "Simulation": "simulation" / noArgs
           , "MarloweEditor": "marlowe" / noArgs
+          , "ImportContract": "importContract" / (param "contract")
           , "HaskellEditor": "haskell" / noArgs
           , "JSEditor": "javascript" / noArgs
           , "Blockly": "blockly" / noArgs
           , "GithubAuthCallback": "gh-oauth-cb" / noArgs
           }
   where
+  _importedContract = Proxy :: _ "importedContract"
+
   _gistId = Proxy :: _ "gistId"
 
   _subroute = Proxy :: _ "subroute"

--- a/marlowe-playground-client/src/Web/Blob/CompressString.js
+++ b/marlowe-playground-client/src/Web/Blob/CompressString.js
@@ -3,3 +3,7 @@ import LZString from 'lz-string';
 export function compressToURI(originalString) {
     return LZString.compressToEncodedURIComponent(originalString);
 }
+
+export function decompressFromURI(compressedString) {
+    return LZString.decompressFromEncodedURIComponent(compressedString);
+}

--- a/marlowe-playground-client/src/Web/Blob/CompressString.purs
+++ b/marlowe-playground-client/src/Web/Blob/CompressString.purs
@@ -1,3 +1,5 @@
-module Web.Blob.CompressString (compressToURI) where
+module Web.Blob.CompressString (compressToURI, decompressFromURI) where
 
 foreign import compressToURI :: String -> String
+
+foreign import decompressFromURI :: String -> String


### PR DESCRIPTION
This PR adds an endpoint to the Marlowe Playground to import compressed JSON contracts from other apps (in particular from Marlowe Runner). The endpoint is called `importContract` and takes the compressed JSON of the contract as the parameter `contract`.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
