### PR TITLE
PLT-8277 - Add a button to copy to the clipboard a link to the current contract in the Marlowe editor

### DIFF
--- a/changelog.d/20231026_200217_pablo.lamela_PLT_8277.md
+++ b/changelog.d/20231026_200217_pablo.lamela_PLT_8277.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- Added a button to copy to the clipboard a link to the current contract in the Marlowe editor
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -259,7 +259,7 @@ handleSubRoute Router.MarloweEditor = selectView MarloweEditor
 
 handleSubRoute (Router.ImportContract contract) = do
   handleActionWithoutNavigationGuard
-    (MarloweEditorAction (ME.ImportCompressedJSON contract))
+    (MarloweEditorAction (ME.ImportCompressedContract contract))
   selectView MarloweEditor
 
 handleSubRoute Router.HaskellEditor = selectView HaskellEditor

--- a/marlowe-playground-client/src/Page/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/Page/MarloweEditor/State.purs
@@ -11,6 +11,7 @@ import Component.BottomPanel.Types (Action(..), State) as BottomPanel
 import Control.Monad.Except (lift)
 import Control.Monad.Maybe.Extra (hoistMaybe)
 import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
+import Data.Argonaut (encodeJson, stringify)
 import Data.Argonaut.Extra (parseDecodeJson)
 import Data.Array as Array
 import Data.Either (hush)
@@ -20,10 +21,11 @@ import Data.Lens.Index (ix)
 import Data.Map as Map
 import Data.Map.Ordered.OMap as OMap
 import Data.Maybe (fromMaybe)
-import Data.String (Pattern(..), codePointFromChar, contains)
+import Data.String (Pattern(..), codePointFromChar, contains, length, splitAt)
 import Data.String as String
 import Data.Time.Duration (Minutes(..))
 import Effect.Aff.Class (class MonadAff, liftAff)
+import Effect.Console (error)
 import Effect.Now (now)
 import Examples.Marlowe.Contracts (example) as ME
 import Halogen (HalogenM, liftEffect, modify_, query)
@@ -57,6 +59,8 @@ import Page.MarloweEditor.Types
   , _selectedHole
   , _showErrorDetail
   )
+import Router (SubRoute(..)) as Route
+import Router (printSubRoute)
 import Servant.PureScript (class MonadAjax)
 import SessionStorage as SessionStorage
 import StaticAnalysis.Reachability
@@ -73,7 +77,9 @@ import StaticAnalysis.Types
 import StaticData (marloweBufferLocalStorageKey)
 import StaticData as StaticData
 import Text.Pretty (pretty)
-import Web.Blob.CompressString (decompressFromURI)
+import Web.Blob.Clipboard (copyToClipboard)
+import Web.Blob.CompressString (compressToURI, decompressFromURI)
+import Web.Blob.Window (getUrl)
 import Web.Event.Extra (preventDefault, readFileFromDragEvent)
 
 toBottomPanel
@@ -169,6 +175,35 @@ handleAction _ (ShowErrorDetail val) = assign _showErrorDetail val
 handleAction _ SendToSimulator = pure unit
 
 handleAction _ ViewAsBlockly = pure unit
+
+handleAction _ CopyContractLink = do
+  url <- liftEffect getUrl
+  mResult <-
+    ( runMaybeT $ do
+        contents <- MaybeT $ editorGetValue
+        contract <- hoistMaybe $ parseContract' contents
+        let compressedContract = compressToURI $ stringify $ encodeJson contract
+        hoistMaybe $ composeURL url compressedContract
+    )
+  case mResult of
+    Just result -> liftAff $ copyToClipboard result
+    Nothing -> liftEffect $ error "Could not encode contract as a link"
+
+  where
+  composeURL :: String -> String -> Maybe String
+  composeURL url compCont = do
+    baseUrl <- removeSuffix url (printSubRoute Route.MarloweEditor)
+    pure $ baseUrl <> (printSubRoute (Route.ImportContract compCont))
+
+  removeSuffix :: String -> String -> Maybe String
+  removeSuffix str suffix =
+    let
+      { before: strPrefix, after: strSuffix } = splitAt
+        (length str - length suffix)
+        str
+    in
+      if strSuffix == suffix then Just $ strPrefix
+      else Nothing
 
 handleAction _ (InitMarloweProject contents) = do
   editorSetValue contents

--- a/marlowe-playground-client/src/Page/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/Page/MarloweEditor/Types.purs
@@ -32,7 +32,7 @@ data Action
   | MoveToPosition Pos Pos
   | LoadScript String
   | SetEditorText String
-  | ImportCompressedJSON String
+  | ImportCompressedContract String
   | BottomPanelAction (BottomPanel.Action BottomPanelView Action)
   | ShowErrorDetail Boolean
   | SendToSimulator
@@ -61,7 +61,8 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (LoadScript script) = Just $ (defaultEvent "LoadScript")
     { label = Just script }
   toEvent (SetEditorText _) = Just $ defaultEvent "SetEditorText"
-  toEvent (ImportCompressedJSON _) = Just $ defaultEvent "ImportCompressedJSON"
+  toEvent (ImportCompressedContract _) = Just $ defaultEvent
+    "ImportCompressedContract"
   toEvent (BottomPanelAction action) = A.toEvent action
   toEvent (ShowErrorDetail _) = Just $ defaultEvent "ShowErrorDetail"
   toEvent SendToSimulator = Just $ defaultEvent "SendToSimulator"

--- a/marlowe-playground-client/src/Page/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/Page/MarloweEditor/Types.purs
@@ -37,6 +37,7 @@ data Action
   | ShowErrorDetail Boolean
   | SendToSimulator
   | ViewAsBlockly
+  | CopyContractLink
   | InitMarloweProject String
   | SelectHole (Maybe String)
   | MetadataAction MetadataAction
@@ -65,6 +66,7 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (ShowErrorDetail _) = Just $ defaultEvent "ShowErrorDetail"
   toEvent SendToSimulator = Just $ defaultEvent "SendToSimulator"
   toEvent ViewAsBlockly = Just $ defaultEvent "ViewAsBlockly"
+  toEvent CopyContractLink = Just $ defaultEvent "CopyContractLink"
   toEvent (InitMarloweProject _) = Just $ defaultEvent "InitMarloweProject"
   toEvent (SelectHole _) = Just $ defaultEvent "SelectHole"
   toEvent (MetadataAction action) = Just $ (defaultEvent "MetadataAction")

--- a/marlowe-playground-client/src/Page/MarloweEditor/View.purs
+++ b/marlowe-playground-client/src/Page/MarloweEditor/View.purs
@@ -1,4 +1,8 @@
-module Page.MarloweEditor.View where
+module Page.MarloweEditor.View
+  ( otherActions
+  , render
+  , sendToSimulatorButton
+  ) where
 
 import Prologue hiding (div)
 
@@ -92,6 +96,7 @@ otherActions
 otherActions state =
   div [ classes [ group ] ]
     [ editorOptions state
+    , copyLink state
     , viewAsBlocklyButton state
     , sendToSimulatorButton state
     ]
@@ -140,6 +145,30 @@ viewAsBlocklyButton state =
       ]
     else
       []
+
+copyLink
+  :: forall m
+   . MonadAff m
+  => State
+  -> ComponentHTML Action ChildSlots m
+copyLink state =
+  div [ HP.id "copyContractLink", classNames [ "relative" ] ]
+    [ button
+        [ onClick $ const CopyContractLink
+        , disabled disabled'
+        , classNames [ "btn" ]
+        ]
+        [ text "Copy Link" ]
+    , tooltip tooltipMessage (RefId "copyContractLink") Bottom
+    ]
+  where
+  disabled' = contractHasErrors state || contractHasHoles state
+
+  tooltipMessage =
+    if disabled' then
+      "A contract link can only be generated if the contract has no errors and no holes"
+    else
+      "Copy a link to the Marlowe editor with the current contract encoded in the URL"
 
 editorOptions :: forall p. State -> HTML p Action
 editorOptions state =

--- a/marlowe-playground-client/src/Page/MarloweEditor/View.purs
+++ b/marlowe-playground-client/src/Page/MarloweEditor/View.purs
@@ -162,11 +162,11 @@ copyLink state =
     , tooltip tooltipMessage (RefId "copyContractLink") Bottom
     ]
   where
-  disabled' = contractHasErrors state || contractHasHoles state
+  disabled' = contractHasErrors state
 
   tooltipMessage =
     if disabled' then
-      "A contract link can only be generated if the contract has no errors and no holes"
+      "A contract link can only be generated if the contract has no errors"
     else
       "Copy a link to the Marlowe editor with the current contract encoded in the URL"
 

--- a/marlowe-playground-client/src/Router.purs
+++ b/marlowe-playground-client/src/Router.purs
@@ -7,6 +7,7 @@ import Data.Newtype (unwrap)
 import Data.Profunctor (dimap)
 import Gists.Extra (GistId(..))
 import Routing.Duplex (RouteDuplex', optional, param, record, root, (:=))
+import Routing.Duplex as Route
 import Routing.Duplex.Generic (noArgs, sum)
 import Routing.Duplex.Generic.Syntax ((/))
 import Type.Proxy (Proxy(..))
@@ -52,3 +53,6 @@ route =
   _gistId = Proxy :: _ "gistId"
 
   _subroute = Proxy :: _ "subroute"
+
+printSubRoute :: SubRoute -> String
+printSubRoute sr = Route.print route { gistId: Nothing, subroute: sr }

--- a/marlowe-playground-client/src/Web/Blob/Clipboard.js
+++ b/marlowe-playground-client/src/Web/Blob/Clipboard.js
@@ -1,0 +1,5 @@
+"use strict";
+
+export function copyToClipboardImpl(text, onFulfilled, onRejected) {
+  return navigator.clipboard.writeText(text);
+};

--- a/marlowe-playground-client/src/Web/Blob/Clipboard.purs
+++ b/marlowe-playground-client/src/Web/Blob/Clipboard.purs
@@ -1,0 +1,12 @@
+module Web.Blob.Clipboard (copyToClipboard) where
+
+import Prelude
+
+import Control.Promise (Promise, toAffE)
+import Effect.Aff (Aff)
+import Effect.Uncurried (EffectFn1, runEffectFn1)
+
+foreign import copyToClipboardImpl :: EffectFn1 String (Promise Unit)
+
+copyToClipboard :: String -> Aff Unit
+copyToClipboard str = toAffE (runEffectFn1 copyToClipboardImpl str)

--- a/marlowe-playground-client/src/Web/Blob/Window.js
+++ b/marlowe-playground-client/src/Web/Blob/Window.js
@@ -1,0 +1,6 @@
+"use strict";
+
+export function getUrlImpl() {
+    return window.location.href;
+};
+

--- a/marlowe-playground-client/src/Web/Blob/Window.purs
+++ b/marlowe-playground-client/src/Web/Blob/Window.purs
@@ -1,0 +1,11 @@
+module Web.Blob.Window (getUrl) where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Uncurried (EffectFn1, runEffectFn1)
+
+foreign import getUrlImpl :: EffectFn1 Unit String
+
+getUrl :: Effect String
+getUrl = runEffectFn1 getUrlImpl unit


### PR DESCRIPTION
This PR adds a button to the Marlowe Editor that copies to the clipboard a link that will load the current contract in the Marlowe Editor when clicked. The button only works for correct contracts with no holes, since it has to be encoded as JSON.

![image](https://github.com/input-output-hk/marlowe-playground/assets/638102/b10cbcca-28e0-4c09-bb03-a253dfb008c1)

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
