### PR TITLE
Improved address pretty render

### DIFF
--- a/changelog.d/20231027_140636_hrajchert_fix_addr_show.md
+++ b/changelog.d/20231027_140636_hrajchert_fix_addr_show.md
@@ -1,0 +1,40 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+### Added
+
+- Change the way addresses are summarised to make testnet ones easy to tell apart by showing both prefix and suffix.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/marlowe-playground-client/src/Page/Simulation/View.purs
+++ b/marlowe-playground-client/src/Page/Simulation/View.purs
@@ -687,15 +687,11 @@ participant metadata state party actionInputs =
         [ h6_
             [ em [ classNames [ "mr-1" ] ]
                 [ text "Participant "
-                , strong_ [ text partyName ]
+                , strong_ [ renderPrettyParty metadata party ]
                 ]
             , partyHint
             ]
         ]
-
-  partyName = case party of
-    (Address name) -> name
-    (Role name) -> name
 
 choiceRef :: String -> ChoiceId -> String
 choiceRef prefix (ChoiceId choiceName choiceOwner) = intercalate "-"

--- a/marlowe-playground-client/src/Pretty.purs
+++ b/marlowe-playground-client/src/Pretty.purs
@@ -14,13 +14,18 @@ import Data.Numbers.Natural as N
 import Data.String as String
 import Halogen.HTML (HTML, abbr, text)
 import Halogen.HTML.Properties (title)
-import Language.Marlowe.Core.V1.Semantics.Types (Party(..), Payee(..))
+import Language.Marlowe.Core.V1.Semantics.Types (Address, Party(..), Payee(..))
 import Language.Marlowe.Extended.V1.Metadata.Types (MetaData, NumberFormat(..))
+
+prettyAddress :: Address -> String
+prettyAddress addr = String.take 9 addr <> "..." <> takeEnd 5 addr
+  where
+  takeEnd n str = String.drop (String.length str - n) str
 
 renderPrettyParty :: forall p i. MetaData -> Party -> HTML p i
 renderPrettyParty _ (Address addr) =
   if String.length addr > 10 then abbr [ title $ "address " <> addr ]
-    [ text $ String.take 10 addr ]
+    [ text $ prettyAddress addr ]
   else text addr
 
 renderPrettyParty metadata (Role role) = abbr


### PR DESCRIPTION
This PR modifies how addresses are pretty printed in several locations. 

Before:
<img width="548" alt="Screenshot 2023-10-26 at 19 57 42" src="https://github.com/input-output-hk/marlowe-playground/assets/2634059/8b874a35-ba15-4004-b943-f52582df573b">

After:
<img width="546" alt="Screenshot 2023-10-26 at 20 56 50" src="https://github.com/input-output-hk/marlowe-playground/assets/2634059/c7581de5-c444-4b3e-a6eb-f64dc3599340">
