### PR TITLE
PLT-7305 - Improve error message on invalid addresses

### DIFF
--- a/changelog.d/20231129_061349_pablo.lamela_PLT_7305.md
+++ b/changelog.d/20231129_061349_pablo.lamela_PLT_7305.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Added linting warning when addresses are invalid.
+- Improved error message when trying to do static analysis with invalid addresses.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/marlowe-playground-client/generated/Examples/Marlowe/Contracts.purs
+++ b/marlowe-playground-client/generated/Examples/Marlowe/Contracts.purs
@@ -91,11 +91,11 @@ escrowWithCollateral =
                                          (ChoiceId "Dispute problem" (Role "Seller")) [
                                          (Bound 0 0)])
                                       (Pay (Role "Seller")
-                                         (Party (Address "addr_test1vqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3lgle2"))
+                                         (Party (Address "addr_test1vqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd9tg5t"))
                                          (Token "" "")
                                          (ConstantParam "Collateral amount")
                                          (Pay (Role "Buyer")
-                                            (Party (Address "addr_test1vqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3lgle2"))
+                                            (Party (Address "addr_test1vqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd9tg5t"))
                                             (Token "" "")
                                             (ConstantParam "Collateral amount") Close)))] (TimeParam "Complaint deadline") Close)))] (TimeParam "Dispute by buyer timeout") Close))] (TimeParam "Deposit of price by buyer timeout") Close))] (TimeParam "Deposit of collateral by buyer timeout") Close))] (TimeParam "Collateral deposit by seller timeout") Close"""
 

--- a/marlowe-playground-client/src/Examples/JS/Contracts.purs
+++ b/marlowe-playground-client/src/Examples/JS/Contracts.purs
@@ -90,7 +90,7 @@ escrowWithCollateral =
 
     const buyer: Party = Role("Buyer");
     const seller: Party = Role("Seller");
-    const burnAddress: Party = Address("addr_test1vqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3lgle2");
+    const burnAddress: Party = Address("addr_test1vqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd9tg5t");
 
     const price: Value = ConstantParam("Price");
     const collateral: Value = ConstantParam("Collateral amount");

--- a/marlowe-playground-client/src/Marlowe/LinterText.purs
+++ b/marlowe-playground-client/src/Marlowe/LinterText.purs
@@ -181,6 +181,7 @@ warningType (Warning { warning }) = case warning of
   NegativePayment -> "NegativePayment"
   NegativeDeposit -> "NegativeDeposit"
   TimeoutNotIncreasing -> "TimeoutNotIncreasing"
+  (InvalidAddress _) -> "InvalidAddress"
   UnreachableCaseEmptyChoice -> "UnreachableCaseEmptyChoice"
   InvalidBound -> "InvalidBound"
   UnreachableCaseFalseNotify -> "UnreachableCaseFalseNotify"

--- a/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
@@ -250,6 +250,19 @@ warningAnalysisResult tzOffset staticSubResult = div
               ]
           ]
       ]
+    Failure WarningWrongAddressesInContract ->
+      [ h3 [ classes [ ClassName "analysis-result-title" ] ]
+          [ text "Error during warning analysis" ]
+      , text "Analysis failed for the following reason:"
+      , ul [ classes [ ClassName "indented-enum-initial" ] ]
+          [ li_
+              [ b_
+                  [ spanText
+                      "The code has invalid addresses. Please check the Warnings tab."
+                  ]
+              ]
+          ]
+      ]
     Loading -> [ text "" ]
 
 reachabilityAnalysisResult

--- a/marlowe-playground-client/src/StaticAnalysis/ReachabilityTools.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/ReachabilityTools.purs
@@ -1,0 +1,42 @@
+module StaticAnalysis.ReachabilityTools
+  ( initializePrefixMap
+  , stepPrefixMap
+  ) where
+
+import Prologue hiding (div)
+
+import Control.Monad.State as CMS
+import Data.List (List, any, catMaybes, fromFoldable, null)
+import Data.List.NonEmpty (fromList, head, tail)
+import Data.Map (fromFoldableWith, lookup, unionWith)
+import Data.Map as Map
+import Data.Set (singleton, union)
+import Data.Tuple.Nested ((/\))
+import StaticAnalysis.Types (ContractPath, ContractPathStep, PrefixMap)
+
+-- It groups the contract paths by their head, discards empty contract paths
+initializePrefixMap :: List ContractPath -> PrefixMap
+initializePrefixMap unreachablePathList = fromFoldableWith union
+  $ map (\x -> (head x /\ singleton x))
+  $ catMaybes
+  $ map fromList unreachablePathList
+
+-- Returns Nothing when the path is unreachable according to one of the paths, otherwise it returns the updated PrefixMap for the subpath
+stepPrefixMap
+  :: forall a
+   . CMS.State a Unit
+  -> PrefixMap
+  -> ContractPathStep
+  -> CMS.State a (Maybe PrefixMap)
+stepPrefixMap markUnreachable prefixMap contractPath =
+  case lookup contractPath prefixMap of
+    Just pathSet ->
+      let
+        tails = map tail $ fromFoldable pathSet
+      in
+        if any null tails then do
+          markUnreachable
+          pure Nothing
+        else
+          pure $ Just $ unionWith union (initializePrefixMap tails) Map.empty
+    Nothing -> pure (Just Map.empty)

--- a/marlowe-playground-client/src/Text/Bech32.purs
+++ b/marlowe-playground-client/src/Text/Bech32.purs
@@ -14,6 +14,7 @@ import Data.String.CodeUnits (fromCharArray, indexOf, toCharArray)
 import Data.Traversable (traverse)
 import Data.Tuple.Nested (type (/\), (/\))
 
+-- Based on code and spec in: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki (licensed under: BSD-2-Clause)
 gen :: Array Int
 gen = [ 0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3 ]
 
@@ -70,6 +71,7 @@ splitAddress s = do
     )
   pure $ (hrp /\ intDataArr)
 
+-- Based on: https://cips.cardano.org/cips/cip19/ (licensed under: CC-BY-4.0)
 validPaymentShelleyAddress :: String -> Boolean
 validPaymentShelleyAddress sAddr =
   fromMaybe false

--- a/marlowe-playground-client/src/Text/Bech32.purs
+++ b/marlowe-playground-client/src/Text/Bech32.purs
@@ -1,0 +1,88 @@
+module Text.Bech32 (validPaymentShelleyAddress) where
+
+import Prelude
+
+import Control.Alternative (guard)
+import Data.Array (range, uncons, (!!))
+import Data.Char (toCharCode)
+import Data.Foldable (all, foldl)
+import Data.Int.Bits (shl, shr, xor, (.&.), (.|.))
+import Data.Maybe (Maybe, fromMaybe)
+import Data.String (Pattern(..), lastIndexOf, length, splitAt, stripSuffix)
+import Data.String.CodeUnits (fromCharArray, indexOf, toCharArray)
+import Data.Traversable (traverse)
+import Data.Tuple.Nested (type (/\), (/\))
+
+gen :: Array Int
+gen = [ 0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3 ]
+
+charTable :: String
+charTable = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+bech32Polymod :: Array Int -> Int
+bech32Polymod values = foldl go 1 values
+  where
+  go chk v =
+    let
+      b = shr chk 25
+    in
+      foldl
+        ( \acc i ->
+            acc `xor`
+              ( if (shr b i .&. 1) == 1 then fromMaybe 0 (gen !! i)
+                else 0
+              )
+        )
+        (shl (chk .&. 0x1ffffff) 5 `xor` v)
+        (range 0 4)
+
+bech32HrpExpand :: String -> Array Int
+bech32HrpExpand s = map (\c -> shr (toCharCode c) 5) (toCharArray s) <> [ 0 ] <>
+  map (\c -> toCharCode c .&. 31) (toCharArray s)
+
+bech32VerifyChecksum :: String -> Array Int -> Boolean
+bech32VerifyChecksum hrp data' = bech32Polymod (bech32HrpExpand hrp <> data') ==
+  1
+
+stringToIntArray :: String -> Maybe (Array Int)
+stringToIntArray s = traverse go (toCharArray s)
+  where
+  go :: Char -> Maybe Int
+  go c = indexOf (Pattern (fromCharArray [ c ])) charTable
+
+validCharacters :: String -> Boolean
+validCharacters s = all ((\c -> c >= 33 && c <= 126) <<< toCharCode)
+  (toCharArray s)
+
+splitAddress :: String -> Maybe (String /\ Array Int)
+splitAddress s = do
+  p <- lastIndexOf (Pattern "1") s
+  let { before: hrp1, after: data' } = splitAt (p + 1) s
+  hrp <- stripSuffix (Pattern "1") hrp1
+  let
+    hrpl = length hrp
+    datal = length data'
+  intDataArr <- stringToIntArray data'
+  guard
+    ( hrpl >= 1 && validCharacters hrp && datal >= 6 && bech32VerifyChecksum hrp
+        intDataArr
+    )
+  pure $ (hrp /\ intDataArr)
+
+validPaymentShelleyAddress :: String -> Boolean
+validPaymentShelleyAddress sAddr =
+  fromMaybe false
+    do
+      (pref /\ dat) <- splitAddress sAddr
+      { head: b_0_5, tail: t } <- uncons dat -- First 5 bits
+      { head: b_6_10, tail: _ } <- uncons t -- Second 5 bits
+      let
+        addrType = shr b_0_5 1
+        network = (shl (b_0_5 .&. 0x01) 3) .|. (shr b_6_10 2)
+      pure $
+        ( (pref == "addr_test" && network == 0) ||
+            (pref == "addr" && network == 1)
+        ) -- Header matches network
+
+          && addrType <= 7 -- It is a payment key (not a stake address)
+          && addrType .&. 0x01 == 0 -- It is not a script address

--- a/marlowe-playground-client/src/Text/Bech32.purs
+++ b/marlowe-playground-client/src/Text/Bech32.purs
@@ -88,9 +88,12 @@ validPaymentShelleyAddress sAddr =
 
           && addrType <= 7 -- It is a payment key (not a stake address)
           && addrType .&. 0x01 == 0 -- It is not a script address
+          && addrType /= 4
+          && addrType /= 5 -- No pointer
           &&
             ( if addrType < 6 -- Does it have two hashes?
-              then datLength == 101 &&
-                (fromMaybe false (map ((>) 0x10) dat !! 95)) -- 8 + 224 + 224 + 48 = 504 bits = 100 chars of 5 bits + 4 (bits)
-              else datLength == 56
-            ) -- 8 + 224 + 48 = 280 -> 56 chars of 5 bits
+              then datLength == 98 &&
+                (fromMaybe false (map (\x -> x .&. 1 == 0) dat !! 91)) -- 8 + 224 + 224 + 30 = 486 bits = 97 chars of 5 bits + 1 bit
+              else datLength == 53 &&
+                (fromMaybe false (map (\x -> x .&. 7 == 0) dat !! 46))
+            ) -- 8 + 224 + 30 = 262 -> 52 chars of 5 bits + 2 bits

--- a/marlowe-playground-client/src/Types.purs
+++ b/marlowe-playground-client/src/Types.purs
@@ -15,6 +15,7 @@ type JsonAjaxError = AjaxError JsonDecodeError Json
 data WarningAnalysisError
   = WarningAnalysisAjaxError JsonAjaxError
   | WarningAnalysisIsExtendedMarloweError
+  | WarningWrongAddressesInContract
 
 type WebData = RemoteData JsonAjaxError
 

--- a/marlowe-playground-client/test/Main.purs
+++ b/marlowe-playground-client/test/Main.purs
@@ -16,6 +16,7 @@ import Test.Component.DateTimeLocalInputTest as DateTimeLocalInputTest
 import Test.Humanize as HumanizeTest
 import Test.Spec.Reporter (consoleReporter)
 import Test.Spec.Runner (runSpec)
+import Test.Text.Bech32Tests as Bech32Tests
 
 foreign import forDeps :: Effect Unit
 
@@ -31,3 +32,4 @@ main = launchAff_ $ runSpec [ consoleReporter ] do
   HolesTimeoutTest.all
   DateTimeLocalInputTest.all
   HumanizeTest.all
+  Bech32Tests.all

--- a/marlowe-playground-client/test/Text/Bech32Tests.purs
+++ b/marlowe-playground-client/test/Text/Bech32Tests.purs
@@ -13,6 +13,7 @@ all :: Spec Unit
 all =
   describe "Shelley address check" do
     mainnetPaymentKeyAddresses
+    invalidPaymentKeyAddresses
     mainnetScriptKeyAddresses
     mainnetStakeAddresses
     testnetPaymentKeyAddresses
@@ -27,6 +28,16 @@ mainnetPaymentKeyAddresses =
       , "addr1yx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerkr0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shs2z78ve" -- type-02
       , "addr1gx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrzqf96k" -- type-04
       , "addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8" -- type-06
+      ]
+
+invalidPaymentKeyAddresses :: Spec Unit
+invalidPaymentKeyAddresses =
+  it "Invalid addresses" do
+    traverse_ (\addr -> shouldNotSatisfy addr validPaymentShelleyAddress)
+      [ "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3nqd3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x" -- type-00 (bad checksum)
+      , "addr1yx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerkr0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9ulr5d2shs2z78ve" -- type-02 (bad checksum)
+      , "addr_test1gx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrzqf96k" -- type-04 (bad network label/bit)
+      , "addr1vx2fxv2umyhttkxyxp1x0dlpdt3k6cwng5pxj3jhsydzers66hrl8" -- type-06 (bad label)
       ]
 
 mainnetScriptKeyAddresses :: Spec Unit

--- a/marlowe-playground-client/test/Text/Bech32Tests.purs
+++ b/marlowe-playground-client/test/Text/Bech32Tests.purs
@@ -14,10 +14,10 @@ all =
   describe "Shelley address check" do
     mainnetPaymentKeyAddresses
     invalidPaymentKeyAddresses
-    mainnetScriptKeyAddresses
+    mainnetScriptAndPointerKeyAddresses
     mainnetStakeAddresses
     testnetPaymentKeyAddresses
-    testnetScriptKeyAddresses
+    testnetScriptAndPointerAddresses
     testnetStakeAddresses
 
 mainnetPaymentKeyAddresses :: Spec Unit
@@ -26,7 +26,6 @@ mainnetPaymentKeyAddresses =
     traverse_ (\addr -> shouldSatisfy addr validPaymentShelleyAddress)
       [ "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x" -- type-00
       , "addr1yx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerkr0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shs2z78ve" -- type-02
-      , "addr1gx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrzqf96k" -- type-04
       , "addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8" -- type-06
       ]
 
@@ -40,12 +39,13 @@ invalidPaymentKeyAddresses =
       , "addr1vx2fxv2umyhttkxyxp1x0dlpdt3k6cwng5pxj3jhsydzers66hrl8" -- type-06 (bad label)
       ]
 
-mainnetScriptKeyAddresses :: Spec Unit
-mainnetScriptKeyAddresses =
-  it "Mainnet script addresses" do
+mainnetScriptAndPointerKeyAddresses :: Spec Unit
+mainnetScriptAndPointerKeyAddresses =
+  it "Mainnet script and pointer addresses" do
     traverse_ (\addr -> shouldNotSatisfy addr validPaymentShelleyAddress)
       [ "addr1z8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs9yc0hh" -- type-01
       , "addr1x8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gt7r0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shskhj42g" -- type-03
+      , "addr1gx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrzqf96k" -- type-04
       , "addr128phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtupnz75xxcrtw79hu" -- type-05
       , "addr1w8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcyjy7wx" -- type-07
       ]
@@ -64,16 +64,16 @@ testnetPaymentKeyAddresses =
     traverse_ (\addr -> shouldSatisfy addr validPaymentShelleyAddress)
       [ "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs68faae" -- type-00
       , "addr_test1yz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerkr0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shsf5r8qx" -- type-02
-      , "addr_test1gz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrdw5vky" -- type-04
       , "addr_test1vz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspjrlsz" -- type-06
       ]
 
-testnetScriptKeyAddresses :: Spec Unit
-testnetScriptKeyAddresses =
-  it "Testnet script addresses" do
+testnetScriptAndPointerAddresses :: Spec Unit
+testnetScriptAndPointerAddresses =
+  it "Testnet script and pointer addresses" do
     traverse_ (\addr -> shouldNotSatisfy addr validPaymentShelleyAddress)
       [ "addr_test1zrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgsxj90mg" -- type-01
       , "addr_test1xrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gt7r0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shs4p04xh" -- type-03
+      , "addr_test1gz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrdw5vky" -- type-04
       , "addr_test12rphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtupnz75xxcryqrvmw" -- type-05
       , "addr_test1wrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcl6szpr" -- type-07
       ]

--- a/marlowe-playground-client/test/Text/Bech32Tests.purs
+++ b/marlowe-playground-client/test/Text/Bech32Tests.purs
@@ -20,6 +20,7 @@ all =
     testnetScriptAndPointerAddresses
     testnetStakeAddresses
 
+-- Part of the test vectors are obtained or derived from: https://cips.cardano.org/cips/cip19/ (licensed under: CC-BY.4.0)
 mainnetPaymentKeyAddresses :: Spec Unit
 mainnetPaymentKeyAddresses =
   it "Mainnet payment key addresses" do

--- a/marlowe-playground-client/test/Text/Bech32Tests.purs
+++ b/marlowe-playground-client/test/Text/Bech32Tests.purs
@@ -1,0 +1,76 @@
+module Test.Text.Bech32Tests
+  ( all
+  ) where
+
+import Prologue
+
+import Data.Foldable (traverse_)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldNotSatisfy, shouldSatisfy)
+import Text.Bech32 (validPaymentShelleyAddress)
+
+all :: Spec Unit
+all =
+  describe "Shelley address check" do
+    mainnetPaymentKeyAddresses
+    mainnetScriptKeyAddresses
+    mainnetStakeAddresses
+    testnetPaymentKeyAddresses
+    testnetScriptKeyAddresses
+    testnetStakeAddresses
+
+mainnetPaymentKeyAddresses :: Spec Unit
+mainnetPaymentKeyAddresses =
+  it "Mainnet payment key addresses" do
+    traverse_ (\addr -> shouldSatisfy addr validPaymentShelleyAddress)
+      [ "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x" -- type-00
+      , "addr1yx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerkr0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shs2z78ve" -- type-02
+      , "addr1gx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrzqf96k" -- type-04
+      , "addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8" -- type-06
+      ]
+
+mainnetScriptKeyAddresses :: Spec Unit
+mainnetScriptKeyAddresses =
+  it "Mainnet script addresses" do
+    traverse_ (\addr -> shouldNotSatisfy addr validPaymentShelleyAddress)
+      [ "addr1z8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs9yc0hh" -- type-01
+      , "addr1x8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gt7r0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shskhj42g" -- type-03
+      , "addr128phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtupnz75xxcrtw79hu" -- type-05
+      , "addr1w8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcyjy7wx" -- type-07
+      ]
+
+mainnetStakeAddresses :: Spec Unit
+mainnetStakeAddresses =
+  it "Mainnet stake addresses" do
+    traverse_ (\addr -> shouldNotSatisfy addr validPaymentShelleyAddress)
+      [ "stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw" -- type-14
+      , "stake178phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcccycj5" -- type-15
+      ]
+
+testnetPaymentKeyAddresses :: Spec Unit
+testnetPaymentKeyAddresses =
+  it "Testnet payment key addresses" do
+    traverse_ (\addr -> shouldSatisfy addr validPaymentShelleyAddress)
+      [ "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs68faae" -- type-00
+      , "addr_test1yz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerkr0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shsf5r8qx" -- type-02
+      , "addr_test1gz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrdw5vky" -- type-04
+      , "addr_test1vz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspjrlsz" -- type-06
+      ]
+
+testnetScriptKeyAddresses :: Spec Unit
+testnetScriptKeyAddresses =
+  it "Testnet script addresses" do
+    traverse_ (\addr -> shouldNotSatisfy addr validPaymentShelleyAddress)
+      [ "addr_test1zrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgsxj90mg" -- type-01
+      , "addr_test1xrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gt7r0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shs4p04xh" -- type-03
+      , "addr_test12rphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtupnz75xxcryqrvmw" -- type-05
+      , "addr_test1wrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcl6szpr" -- type-07
+      ]
+
+testnetStakeAddresses :: Spec Unit
+testnetStakeAddresses =
+  it "Testnet stake addresses" do
+    traverse_ (\addr -> shouldNotSatisfy addr validPaymentShelleyAddress)
+      [ "stake_test1uqehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gssrtvn" -- type-14
+      , "stake_test17rphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcljw6kf" -- type-15
+      ]

--- a/web-common-marlowe/src/Examples/PureScript/EscrowWithCollateral.purs
+++ b/web-common-marlowe/src/Examples/PureScript/EscrowWithCollateral.purs
@@ -148,7 +148,7 @@ seller = Role "Seller"
 
 burnAddress :: Party
 burnAddress = Address
-  "addr_test1vqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3lgle2"
+  "addr_test1vqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd9tg5t"
 
 price :: Value
 price = ConstantParam "Price"


### PR DESCRIPTION
This PR:
- Adds linting warning when addresses are invalid.
- Show an error when trying to statically analyze contracts with invalid addresses (which solves the huge and cryptic error messages obtained before)
- Updates the burn address in the escrow with collateral example, so that it has the right length and doesn't crash the static analysis
- Adds pertinent tests

In order to achieve this, the PR also implements the address validation algorithm in PureScript, with the following caveats:
- It doesn't support paying to script (it would be misleading since, as I understand it, it is not feasible because there is no way of providing a datum)
- It doesn't support pointers (the serialization code in Haskell doesn't either)

I am tagging @bwbush for expertise on CIP19, and @hrajchert for expertise in PureScript and the Playground.

It would be good to double check the way I am validating the padding of the bech32, I am not 100% confident it is correct.

If you merge the PR, please squash it, because some of the intermediate commits are broken.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
