### PR TITLE
fix: k8s alert increase cpu

### DIFF
--- a/deploy/templates/marlowe-playground.yaml
+++ b/deploy/templates/marlowe-playground.yaml
@@ -8,7 +8,7 @@ spec:
   - name: marlowe-playground
     type: webservice
     properties:
-      cpu: "0.5"
+      cpu: "1"
       image: ghcr.io/input-output-hk/marlowe-playground-server:{{ $.Values.images.stagingTag }}
       args:
       - webserver


### PR DESCRIPTION
Just a small fix to reduce the amount of alerts of `CPUThrottlingHigh`.