### PR TITLE
PLT-8828 - Check that contract is not mixing mainnet and testnet addresses before sending to Runner

### DIFF
--- a/changelog.d/20240127_213938_pablo.lamela_PLT_8828.md
+++ b/changelog.d/20240127_213938_pablo.lamela_PLT_8828.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+### Added
+
+- Added a linter warning for whenever there are networks from both testnet and mainnet.
+- Forbid sending contracts to Marlowe Runner when networks mismatch.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -13,6 +13,7 @@ module Marlowe.Linter
   , _network
   , hasInvalidAddresses
   , isSeveralNetworks
+  , getNetworkFor
   ) where
 
 import Prologue
@@ -1041,3 +1042,6 @@ hasInvalidAddresses ec =
     State { warnings } = lint Nil (toTerm ec)
   in
     any isAddressWarning warnings
+
+getNetworkFor :: Term Contract -> Networks
+getNetworkFor c = let State { network: n } = lint Nil c in n

--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -1,5 +1,6 @@
 module Marlowe.Linter
   ( lint
+  , Networks(..)
   , State(..)
   , MaxTimeout(..)
   , Warning(..)
@@ -9,7 +10,9 @@ module Marlowe.Linter
   , _warnings
   , _metadataHints
   , _location
+  , _network
   , hasInvalidAddresses
+  , isSeveralNetworks
   ) where
 
 import Prologue
@@ -23,18 +26,19 @@ import Data.Eq.Generic (genericEq)
 import Data.Foldable (any, foldM)
 import Data.FoldableWithIndex (traverseWithIndex_)
 import Data.Generic.Rep (class Generic)
-import Data.Lens (Lens', modifying, over, set, view)
+import Data.Lens (Lens', modifying, over, set, use, view)
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
 import Data.List (List(..))
 import Data.Map (Map)
 import Data.Map as Map
-import Data.Maybe (isNothing, maybe)
+import Data.Maybe (isJust, isNothing, maybe)
 import Data.Newtype (class Newtype)
 import Data.Ord.Generic (genericCompare)
 import Data.Set (Set)
 import Data.Set as Set
 import Data.Set.Ordered.OSet as OSet
+import Data.String (Pattern(..), stripPrefix)
 import Data.String (length) as String
 import Data.TextEncoder (encodeUtf8)
 import Data.Tuple.Nested (type (/\), (/\))
@@ -137,6 +141,7 @@ data WarningDetail
   | RoleNameTooLong
   | PolicyIdWrongLength
   | TokenNameTooLong
+  | NetworkMismatch
   | SimplifiableValue (Term Value) (Term Value)
   | SimplifiableObservation (Term Observation) (Term Observation)
   | PayBeforeDeposit S.AccountId
@@ -166,6 +171,8 @@ instance showWarningDetail :: Show WarningDetail where
     "Policy ID is the wrong length (policy IDs must consist of 56 hexadecimal characters or 0 for ADA)"
   show TokenNameTooLong =
     "Token name is too long (token names are limited to 32 bytes)"
+  show NetworkMismatch =
+    "The contract uses addresses from both mainnet and testned. This is very dangerous and can make the Marlowe validator fail to run."
   show (SimplifiableValue oriVal newVal) = "The value \"" <> show oriVal
     <> "\" can be simplified to \""
     <> show newVal
@@ -214,11 +221,38 @@ instance ordWarning :: Ord Warning where
 instance showWarning :: Show Warning where
   show (Warning warn) = show warn.warning
 
+data Networks
+  = Unknown
+  | Mainnet
+  | Testnet
+  | SeveralNetworks
+
+derive instance eqNetwork :: Eq Networks
+
+derive instance ordNetwork :: Ord Networks
+
+instance semigroupNetworks :: Semigroup Networks where
+  append :: Networks -> Networks -> Networks
+  append Unknown x = x
+  append x Unknown = x
+  append x y
+    | x /= y = SeveralNetworks
+    | otherwise = x
+
+instance monoideNetwork :: Monoid Networks where
+  mempty :: Networks
+  mempty = Unknown
+
 newtype State = State
   { holes :: Holes
   , warnings :: Set Warning
   , metadataHints :: MetadataHintInfo
+  , network :: Networks
   }
+
+isSeveralNetworks :: Networks -> Boolean
+isSeveralNetworks SeveralNetworks = true
+isSeveralNetworks _ = false
 
 derive instance newtypeState :: Newtype State _
 
@@ -235,6 +269,9 @@ _warnings = _Newtype <<< prop (Proxy :: _ "warnings")
 _metadataHints :: Lens' State MetadataHintInfo
 _metadataHints = _Newtype <<< prop (Proxy :: _ "metadataHints")
 
+_network :: Lens' State Networks
+_network = _Newtype <<< prop (Proxy :: _ "network")
+
 hasHoles :: State -> Boolean
 hasHoles = not MH.isEmpty <<< view _holes
 
@@ -249,6 +286,23 @@ addValueParameter valueParam = modifying (_metadataHints <<< _valueParameters) $
 addChoiceName :: String -> CMS.State State Unit
 addChoiceName choiceName = modifying (_metadataHints <<< _choiceNames) $
   Set.insert choiceName
+
+addNetwork :: Networks -> CMS.State State Unit
+addNetwork network = modifying _network (\x -> x <> network)
+
+getNetwork :: String -> Networks
+getNetwork str =
+  let
+    startsWith pre = isJust $ stripPrefix (Pattern pre) str
+  in
+    case unit of
+      _
+        | startsWith "addr1" -> Mainnet
+        | startsWith "addr_test1" -> Testnet
+        | otherwise -> Unknown
+
+addAddressNetwork :: String -> CMS.State State Unit
+addAddressNetwork addr = addNetwork (getNetwork addr)
 
 newtype LintEnv = LintEnv
   { choicesMade :: Set S.ChoiceId
@@ -435,11 +489,26 @@ lint unreachablePaths contract =
   let
     env = emptyEnvironment unreachablePaths
   in
-    CMS.execState (lintContract env contract) mempty
+    CMS.execState (addNetworkMismatchWarning (lintContract env contract)) mempty
+
+addNetworkMismatchWarning :: CMS.State State Unit -> CMS.State State Unit
+addNetworkMismatchWarning m = do
+  m
+  n <- use _network
+  if isSeveralNetworks n then addWarning NetworkMismatch
+    ( Range
+        ( { startLineNumber: 0
+          , startColumn: 0
+          , endLineNumber: 0
+          , endColumn: 0
+          }
+        )
+    )
+  else pure unit
 
 lintParty :: Term Party -> CMS.State State Unit
 lintParty (Term (Address addr) pos) =
-  if validPaymentShelleyAddress addr then pure unit
+  if validPaymentShelleyAddress addr then addAddressNetwork addr
   else addWarning (InvalidAddress addr) pos
 
 lintParty (Term (Role role) pos) = do

--- a/marlowe-playground-client/src/Marlowe/LinterText.purs
+++ b/marlowe-playground-client/src/Marlowe/LinterText.purs
@@ -192,6 +192,7 @@ warningType (Warning { warning }) = case warning of
   RoleNameTooLong -> "RoleNameTooLong"
   PolicyIdWrongLength -> "PolicyIdWrongLength"
   TokenNameTooLong -> "TokenNameTooLong"
+  NetworkMismatch -> "NetworkMismatch"
   (SimplifiableValue _ _) -> "SimplifiableValue"
   (SimplifiableObservation _ _) -> "SimplifiableObservation"
   (PayBeforeDeposit _) -> "PayBeforeDeposit"

--- a/marlowe-playground-client/src/Page/Simulation/Lenses.purs
+++ b/marlowe-playground-client/src/Page/Simulation/Lenses.purs
@@ -4,6 +4,7 @@ import Component.BottomPanel.Types as BottomPanel
 import Data.Lens (Lens')
 import Data.Lens.Record (prop)
 import Help (HelpContext)
+import Marlowe.Linter (Networks)
 import Page.Simulation.Types (BottomPanelView, State)
 import Type.Proxy (Proxy(..))
 
@@ -18,3 +19,7 @@ _bottomPanelState = prop (Proxy :: _ "bottomPanelState")
 
 _decorationIds :: Lens' State (Array String)
 _decorationIds = prop (Proxy :: _ "decorationIds")
+
+_network :: Lens' State Networks
+_network = prop (Proxy :: _ "networks")
+

--- a/marlowe-playground-client/src/Page/Simulation/State.purs
+++ b/marlowe-playground-client/src/Page/Simulation/State.purs
@@ -56,6 +56,7 @@ import Marlowe (Api)
 import Marlowe as Server
 import Marlowe.Holes (Contract) as Term
 import Marlowe.Holes (Location(..), Term, fromTerm, getLocation)
+import Marlowe.Linter (getNetworkFor)
 import Marlowe.Monaco as MM
 import Marlowe.Parser (parseContract)
 import Marlowe.Template (_timeContent, _valueContent, fillTemplate)
@@ -65,6 +66,7 @@ import Page.Simulation.Lenses
   ( _bottomPanelState
   , _decorationIds
   , _helpContext
+  , _network
   , _showRightPanel
   )
 import Page.Simulation.Types (Action(..), BottomPanelView(..), State, StateBase)
@@ -112,6 +114,7 @@ mkStateBase tzOffset =
   , helpContext: MarloweHelp
   , bottomPanelState: BottomPanel.initialState CurrentStateView
   , decorationIds: []
+  , networks: mempty
   }
 
 toBottomPanel
@@ -248,14 +251,14 @@ handleAction metadata (LoadContract contents) = do
       _ -> pure Nothing
   let
     mTermContract = hush $ parseContract contents
-  for_ mTermContract \termContract ->
+  for_ mTermContract \termContract -> do
+    assign _network (getNetworkFor termContract)
     assign
       _marloweState
       ( NEL.singleton
           $ initialMarloweState currentTime termContract metadata
               prevTemplateContent
       )
-
   editorSetValue contents
 
 handleAction metadata (BottomPanelAction (BottomPanel.PanelAction action)) =

--- a/marlowe-playground-client/src/Page/Simulation/Types.purs
+++ b/marlowe-playground-client/src/Page/Simulation/Types.purs
@@ -20,6 +20,7 @@ import Language.Marlowe.Core.V1.Semantics.Types
   , ChosenNum
   , InputContent
   )
+import Marlowe.Linter (Networks)
 import Marlowe.Symbolic.Types.Response (Result)
 import Network.RemoteData (RemoteData)
 import Simulator.Types (MarloweState)
@@ -32,6 +33,7 @@ type StateBase r =
   , helpContext :: HelpContext
   -- List of decoration ids used by the monaco editor to track the running contract
   , decorationIds :: Array String
+  , networks :: Networks
   | r
   }
 

--- a/marlowe-playground-client/test/Marlowe/LintTests.purs
+++ b/marlowe-playground-client/test/Marlowe/LintTests.purs
@@ -61,6 +61,12 @@ all = do
     it "reports token name too many bytes" tokenNameTooLongBytesWarning
     it "does not report 32 ANSI-characters token name" tokenNameOkNoWarning
     it "does not report 32 bytes token name" tokenNameOkBytesNoWarning
+    it "reports contract with addresses from different network"
+      networkMismatchWarning
+    it "does not report contract with only addresses from mainnet"
+      mainnetNetworkNoWarning
+    it "does not report contract with only addresses from testnet"
+      testnetNetworkNoWarning
     it "reports bad practices Non-increasing timeouts" nonIncreasingTimeouts
     it "reports unreachable code Unreachable If branch (then)" unreachableThen
     it "reports unreachable code Unreachable If branch (else)" unreachableElse
@@ -554,6 +560,45 @@ tokenNameOkBytesNoWarning = testNoWarning contract
       <> " "
       <> show tokenNameOk
       <> ") (Constant 10)) Close] 2 Close"
+
+networkMismatchWarning :: forall m. MonadThrow Error m => m Unit
+networkMismatchWarning = testWarningSimple contract
+  "The contract uses addresses from both mainnet and testned. This is very dangerous and can make the Marlowe validator fail to run."
+  where
+  addressMainnet =
+    "Address \"addr1qxn6u4ffhafpfvsw876wxllvvae88wekwhsnvpuh4s8fgf0xjsn7s0z25ycztthswazwj7wj0yta5m7d0y32q5aseyys63phd5\""
+  addressTestnet =
+    "Address \"addr_test1qzn6u4ffhafpfvsw876wxllvvae88wekwhsnvpuh4s8fgf0xjsn7s0z25ycztthswazwj7wj0yta5m7d0y32q5aseyyse8uhpt\""
+  contract =
+    "When [Case (Deposit ("
+      <> addressMainnet
+      <> ") ("
+      <> addressTestnet
+      <> ") (Token \"\" \"\") (Constant 10)) Close] 2 Close"
+
+mainnetNetworkNoWarning :: forall m. MonadThrow Error m => m Unit
+mainnetNetworkNoWarning = testNoWarning contract
+  where
+  addressMainnet =
+    "Address \"addr1qxn6u4ffhafpfvsw876wxllvvae88wekwhsnvpuh4s8fgf0xjsn7s0z25ycztthswazwj7wj0yta5m7d0y32q5aseyys63phd5\""
+  contract =
+    "When [Case (Deposit ("
+      <> addressMainnet
+      <> ") ("
+      <> addressMainnet
+      <> ") (Token \"\" \"\") (Constant 10)) Close] 2 Close"
+
+testnetNetworkNoWarning :: forall m. MonadThrow Error m => m Unit
+testnetNetworkNoWarning = testNoWarning contract
+  where
+  addressTestnet =
+    "Address \"addr_test1qzn6u4ffhafpfvsw876wxllvvae88wekwhsnvpuh4s8fgf0xjsn7s0z25ycztthswazwj7wj0yta5m7d0y32q5aseyyse8uhpt\""
+  contract =
+    "When [Case (Deposit ("
+      <> addressTestnet
+      <> ") ("
+      <> addressTestnet
+      <> ") (Token \"\" \"\") (Constant 10)) Close] 2 Close"
 
 nonIncreasingTimeouts :: forall m. MonadThrow Error m => m Unit
 nonIncreasingTimeouts = testWarningSimple "When [] 5 (When [] 5 Close)"


### PR DESCRIPTION
This PR:
- Adds a linter warning for whenever there are networks from both testnet and mainnet
- Forbids sending contracts to Marlowe Runner when networks mismatch or they are for mainnet (since it is not supported yet)

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
